### PR TITLE
Add encoding to np.load

### DIFF
--- a/pspnet.py
+++ b/pspnet.py
@@ -90,7 +90,7 @@ class PSPNet(object):
         h5_path = join("weights", "keras", weights_path + ".h5")
 
         print("Importing weights from %s" % npy_weights_path)
-        weights = np.load(npy_weights_path).item()
+        weights = np.load(npy_weights_path, encoding="latin1").item()
 
         whitelist = ["InputLayer", "Activation", "ZeroPadding2D", "Add", "MaxPooling2D", "AveragePooling2D", "Lambda", "Concatenate", "Dropout"]
 


### PR DESCRIPTION
For me numpy tried to load using ascii encoding by default and failed. It's probably better to specify the correct encoding.