### PR TITLE
Python3.4+ and modern versions of TensorFlow/Keras support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ List of arguments:
 
 
 
- 


### PR DESCRIPTION
This PR will bring versions support to Python3.4+ and modern versions of TensorFlow/Keras

Ideally, PSPNet will run on every Python, starting from 3.4+

Issues(the same idea):
https://github.com/Vladkryvoruchko/PSPNet-Keras-tensorflow/issues/63
https://github.com/Vladkryvoruchko/PSPNet-Keras-tensorflow/issues/49

As discussed in that issues `.h5` and `.json` models generated by Keras(python3.5), are not supported in python3.6
This is a very general issue, that can occur again on some other versions, even if solution for this case will be provided.
- [ ] Put .npy weights on my personal DropBox: https://github.com/Vladkryvoruchko/PSPNet-Keras-tensorflow/issues/45
- [ ] Download .npy weights on the first run and convert them with current version of Python and Keras. 
- [ ] Load only .npy weights and converting to .h5 .json automatically must resolve https://github.com/Vladkryvoruchko/PSPNet-Keras-tensorflow/issues/56
- [ ] Update to a newer version of TensorFlow/Keras/Scipy and resolve all incompatibilities with different Python versions starting from Python3.4+. Define best combinations if needed
- [ ] Define better environment in requirements.txt/README.md: https://github.com/Vladkryvoruchko/PSPNet-Keras-tensorflow/issues/38

